### PR TITLE
Fix AnimationState Concurrent modification during iteration

### DIFF
--- a/lib/src/animation/animation_state.dart
+++ b/lib/src/animation/animation_state.dart
@@ -587,7 +587,7 @@ class AnimationState extends EventDispatcher {
   void _dispatchTrackEntryEvents() {
     if (_eventDispatchDisabled == false) {
       _eventDispatchDisabled = true;
-      _trackEntryEvents.forEach((trackEntryEvent) {
+      _trackEntryEvents.toList().forEach((trackEntryEvent) {
         trackEntryEvent.trackEntry.dispatchEvent(trackEntryEvent);
         this.dispatchEvent(trackEntryEvent);
       });


### PR DESCRIPTION
A TrackEntryEvent is add to the list during a foreach.

 Concurrent modification during iteration: Instance(length:3) of '_GrowableList'.
#0      List.forEach (dart:core-patch/growable_array.dart:259)
#1      AnimationState._dispatchTrackEntryEvents (package:stagexl_spine/src/animation/animation_state.dart:590:25)
#2      AnimationState.apply (package:stagexl_spine/src/animation/animation_state.dart:211:5)
#3      SkeletonAnimation.advanceTime (package:stagexl_spine/src/stagexl/skeleton_animation.dart:17:11)
#4      Juggler.advanceTime (package:stagexl/src/animation/juggler.dart:271:29)
#5      RenderLoop.advanceTime (package:stagexl/src/display/render_loop.dart:48:13)
#6      CustomRenderLoop.advanceTime (package:core/stagexl/canvas.dart:667:24)
#7      RenderLoopBase._onGlobalFrame (package:stagexl/src/engine/render_loop_base.dart:42:14)
#8      _globalFrameRequest.<anonymous closure>.<anonymous closure> (package:stagexl/src/engine/render_loop_base.dart:15:54)
#9      List.forEach (dart:core-patch/growable_array.dart:258)
#10     _globalFrameRequest.<anonymous closure> (package:stagexl/src/engine/render_loop_base.dart:15:38)